### PR TITLE
Add A2 packets support

### DIFF
--- a/include/xbow440/xbow440.h
+++ b/include/xbow440/xbow440.h
@@ -247,6 +247,14 @@ private:
     bool reading_status_;  //!< True if the read thread is running, false otherwise.
     DataCallback data_handler_; //!< Function pointer to callback function for parsed data
     GetTimeCallback time_handler_; //!< Function pointer to callback function for timestamping
+
+    // scale factors for converting raw data
+    static const double kAccelerometerScaleFactorS1; // scale for m/s^2
+    static const double kGyroscopeScaleFactorS1; // scale for rad/s
+    static const double kTemperatureScaleFactorS1;
+    static const double kAccelerometerScaleFactorS2;
+    static const double kGyroscopeScaleFactorS2;
+    static const double kGyroscopeScaleFactorA2;
 };
 
 }; // end namespace

--- a/include/xbow440/xbow440.h
+++ b/include/xbow440/xbow440.h
@@ -88,6 +88,10 @@ struct ImuData {
     double boardtemp; //degC
     unsigned short counter; //packets
     unsigned short bitstatus;
+
+    double rollangle; // rad (only VG and higher)
+    double pitchangle; // rad (only VG and higher)
+    double yawangle; // rad (only VG and higher)
 };
 
 
@@ -206,7 +210,7 @@ private:
     * serial port.  When a complete packet is received, the parse 
     * method is called to process the data
     * 
-    * @see xbow440::XBOW440::Parse, xbow440::XBOW440::StartReading, xbow440::XBOW440::StopReading
+    * @see xbow440::XBOW440::ParseS, xbow440::XBOW440::StartReading, xbow440::XBOW440::StopReading
     */    
     void ReadSerialPort();
 
@@ -220,7 +224,13 @@ private:
     * Parses a packet of data from the IMU.  Scale factors are 
     * also applied to the data to convert into engineering units.
     */
-    void Parse(unsigned char *data, unsigned short packet_type);
+    void ParseS(unsigned char *data, unsigned short packet_type);
+   /*!
+    * Parses an 'A' packet of data from the IMU.  Scale factors are 
+    * also applied to the data to convert into engineering units.
+    * 'A2' are only sent by the VG, AHRS, NAV series.
+    */
+    void ParseA(unsigned char *data, unsigned short packet_type);
    /*!
     * Calculated a cyclic redundancy check (CRC) on the received
     * data to check for errors in data transmission.

--- a/include/xbow440/xbow440.h
+++ b/include/xbow440/xbow440.h
@@ -82,6 +82,9 @@ struct ImuData {
     double rollrate; //1:rad/s 2:rad
     double pitchrate; //1:rad/s 2:rad
     double yawrate; //1:rad/s 2:rad
+    double roll; //rad
+    double pitch; //rad
+    double yaw; //rad
     double xtemp; //degC
     double ytemp; //degC
     double ztemp; //degC

--- a/src/xbow440.cpp
+++ b/src/xbow440.cpp
@@ -5,6 +5,13 @@ using namespace xbow440;
 #define WIN32_LEAN_AND_MEAN 
 #include "boost/date_time/posix_time/posix_time.hpp"
 
+const double XBOW440::kAccelerometerScaleFactorS1 = 0.002992752075195; // scale for m/s^2
+const double XBOW440::kGyroscopeScaleFactorS1 = 0.000335558297349984; // scale for rad/s
+const double XBOW440::kTemperatureScaleFactorS1 = 0.0030517578125;
+const double XBOW440::kAccelerometerScaleFactorS2 = 0.00000004656612873077393;
+const double XBOW440::kGyroscopeScaleFactorS2 = 0.000000005120213277435059;
+const double XBOW440::kGyroscopeScaleFactorA2 = 9.58737992428526e-5;
+
 void DefaultProcessData(const ImuData& data) {
     std::cout << "IMU440 Packet:" << std::endl;
     std::cout << " Timestamp: " << data.receive_time;
@@ -186,13 +193,6 @@ void XBOW440::Resync() {
 
 void XBOW440::Parse(unsigned char *data, unsigned short packet_type) {
     
-	// scale factors for converting raw data
-	static const double kAccelerometerScaleFactorS1 = 0.002992752075195; // scale for m/s^2
-	static const double kGyroscopeScaleFactorS1 = 0.000335558297349984; // scale for rad/s
-	static const double kTemperatureScaleFactorS1 = 0.0030517578125;
-	static const double kAccelerometerScaleFactorS2 = 0.00000004656612873077393;
-	static const double kGyroscopeScaleFactorS2 = 0.000000005120213277435059;
-
 	// TODO: check CRC
 
     switch (packet_type) {

--- a/src/xbow440.cpp
+++ b/src/xbow440.cpp
@@ -328,17 +328,17 @@ void XBOW440::ParseA(unsigned char *data, unsigned short packet_type) {
 		// roll angle
 		s1contents.cdata[0] = data[1];
 		s1contents.cdata[1] = data[0];
-		imu_data_.ax = s1contents.ssdata*kGyroscopeScaleFactorA2;
+		imu_data_.roll = s1contents.ssdata*kGyroscopeScaleFactorA2;
 
 		// pitch angle
 		s1contents.cdata[0] = data[3];
 		s1contents.cdata[1] = data[2];
-		imu_data_.ay = s1contents.ssdata*kGyroscopeScaleFactorA2;
+		imu_data_.pitch = s1contents.ssdata*kGyroscopeScaleFactorA2;
 
 		// yaw angle true
 		s1contents.cdata[0] = data[5];
 		s1contents.cdata[1] = data[4];
-		imu_data_.az = s1contents.ssdata*kGyroscopeScaleFactorA2;
+		imu_data_.yaw = s1contents.ssdata*kGyroscopeScaleFactorA2;
 
 		// x rate corrected (rad)
 		s1contents.cdata[0] = data[7];

--- a/src/xbow440_node.cc
+++ b/src/xbow440_node.cc
@@ -1,5 +1,7 @@
 #include "ros/ros.h"
 #include "sensor_msgs/Imu.h"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
 #include "xbow440/xbow440.h"
 using namespace xbow440;
@@ -18,6 +20,9 @@ void PublishImuData(const ImuData& data) {
     msg.linear_acceleration.x = data.ax;
     msg.linear_acceleration.y = data.ay;
     msg.linear_acceleration.z = data.az;
+    tf2::Quaternion q;
+    q.setRPY(data.roll, data.pitch, data.yaw);
+    msg.orientation = tf2::toMsg(q);
     imu_pub.publish(msg);
 }
 


### PR DESCRIPTION
We use a VGA440, which sends out `A2` packets by default. In this PR, I've added a method to parse `A?` packets (though currently only A2 packets are supported). I tested out the functionality by comparing the output from this ROS module against what NAV-VIEW 3 shows me.

Thanks!